### PR TITLE
Use const because the variable is never reassigned

### DIFF
--- a/src/dd.js
+++ b/src/dd.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 const callerId = require('caller-id');
 
-let Dumper = require('./dumper');
+const Dumper = require('./dumper');
 
 function dd(obj) {
   const dumper = new Dumper();

--- a/src/dump.js
+++ b/src/dump.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 const callerId = require('caller-id');
 
-let Dumper = require('./dumper');
+const Dumper = require('./dumper');
 
 function dump(obj) {
   const dumper = new Dumper();


### PR DESCRIPTION
`dd.js` and `dump.js` should use `const` instead of `let` because the `Dumper` variable is never reassigned.

https://ponyfoo.com/articles/var-let-const