### PR TITLE
Replace console log

### DIFF
--- a/src/global.js
+++ b/src/global.js
@@ -1,0 +1,18 @@
+/* eslint-disable no-console */
+const callerId = require('caller-id');
+
+let Dumper = require('./dumper');
+
+const log = console.log;
+console.log = dump;
+
+function dump(obj) {
+  const dumper = new Dumper();
+  const caller = callerId.getData();
+
+  // Print the file path, line number and generated dump
+  log(`${caller.filePath}:${caller.lineNumber}:`);
+  log(dumper.generateDump(obj));
+}
+
+module.exports = dump;

--- a/src/global.js
+++ b/src/global.js
@@ -1,9 +1,12 @@
 /* eslint-disable no-console */
 const callerId = require('caller-id');
 
-let Dumper = require('./dumper');
+const Dumper = require('./dumper');
 
+// Temporarily store console.log function
 const log = console.log;
+
+// Override console.log with dump
 console.log = dump;
 
 function dump(obj) {
@@ -13,6 +16,7 @@ function dump(obj) {
   // Print the file path, line number and generated dump
   log(`${caller.filePath}:${caller.lineNumber}:`);
   log(dumper.generateDump(obj));
-}
 
-module.exports = dump;
+  // Revert console.log back to original function
+  console.log = log;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -167,4 +167,20 @@ describe('Dump class tests', () => {
 
     assert.equal(generateDump(weirdObject), expectedOutput);
   });
+
+  it('can replace console.log', () => {
+    const logs = [];
+
+    const log = console.log;
+
+    console.log = (...args) => logs.push(args);
+
+    require('../src/global');
+
+    console.log(true);
+
+    console.log = log;
+
+    assert.equal(generateDump(true), logs[1][0].replace(/\u001b\[.*?m/g, ''));
+  });
 });


### PR DESCRIPTION
I don't know if you want this as part of core, but this is how I'd like to use it.

By importing `global.js` we'll override `console.log` and you'll be able to use Dumper.js without doing anything different than you're used to.